### PR TITLE
lcalStorage role:{}inexistente

### DIFF
--- a/client/src/app/PrivateRouteUser.js
+++ b/client/src/app/PrivateRouteUser.js
@@ -9,7 +9,7 @@ export default function PrivateRouteUser({ component: Component, ...rest }) {
 return (
       <Route {...rest}
          render={props => {
-            return currentUser?.role.description === "Registered" ? <Component {...props} /> : <Redirect to="/signin" />
+            return currentUser?.roleId === 101 ? <Component {...props} /> : <Redirect to="/signin" />
          }}>
       </Route>
    )


### PR DESCRIPTION
current de localStorage no guarda objeto role, el arch /app/privateRouterUser no contemplaba la inexistencia de dicho objeto en el localStorage